### PR TITLE
feat: adicionando integração com swagger-ui;

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Para levantar a API junto com o banco de dados Postgres, execute na pasta raiz:
 
 `docker compose up`
 
+## Swagger
+
+Para acessar o Swagger da aplicação, acesse [/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html).
+
 ## Especificação da API
 
 Para renderizar o Swagger, jogue o conteúdo do arquivo [openapi-spec.yaml](openapi-spec.yaml) no [Swagger Editor](https://editor.swagger.io/).

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.1.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
- a documentação do swagger é gerada automaticamente;
- este http://localhost:8080/swagger-ui/index.html é endereço onde o swagger-ui ficará disponível;
