### PR TITLE
Alterar API de checkout do pedido

### DIFF
--- a/src/main/java/br/com/fiap/soat/techChallenge/api/PedidoApi.java
+++ b/src/main/java/br/com/fiap/soat/techChallenge/api/PedidoApi.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 public class PedidoApi {
@@ -22,8 +21,8 @@ public class PedidoApi {
     }
 
     @PostMapping("/pedidos")
-    public ResponseEntity<PedidoResponse> fazerPedido(@RequestBody PedidoRequest pedidoRequest) {
-        return ResponseEntity.ok(pedidoController.fazerPedido(pedidoRequest.toDomain()));
+    public ResponseEntity<PedidoResponse> fazerCheckoutPedido(@RequestBody PedidoRequest pedidoRequest) {
+        return ResponseEntity.ok(pedidoController.fazerCheckoutPedido(pedidoRequest.toDomain()));
     }
 
     @GetMapping("/pedidos")

--- a/src/main/java/br/com/fiap/soat/techChallenge/config/ControllerBeanConfig.java
+++ b/src/main/java/br/com/fiap/soat/techChallenge/config/ControllerBeanConfig.java
@@ -17,8 +17,8 @@ public class ControllerBeanConfig {
     }
 
     @Bean
-    public PedidoController pedidoController(FazerPedidoUseCasePort fazerPedidoUseCase, ObterPedidosUseCasePort obterPedidosUseCase) {
-        return new PedidoController(fazerPedidoUseCase, obterPedidosUseCase);
+    public PedidoController pedidoController(FazerCheckoutPedidoUseCasePort fazerCheckoutPedidoUseCase, ObterPedidosUseCasePort obterPedidosUseCase) {
+        return new PedidoController(fazerCheckoutPedidoUseCase, obterPedidosUseCase);
     }
 
     @Bean

--- a/src/main/java/br/com/fiap/soat/techChallenge/config/UseCaseBeanConfig.java
+++ b/src/main/java/br/com/fiap/soat/techChallenge/config/UseCaseBeanConfig.java
@@ -42,8 +42,8 @@ public class UseCaseBeanConfig {
     }
 
     @Bean
-    public FazerPedidoUseCasePort fazerPedidoUseCasePort(PedidoGatewayPort pedidoGatewayPort, ProdutoGatewayPort produtoGatewayPort, ClienteGatewayPort clienteGatewayPort) {
-        return new FazerPedidoUseCase(pedidoGatewayPort, produtoGatewayPort, clienteGatewayPort);
+    public FazerCheckoutPedidoUseCasePort fazerCheckoutPedidoUseCasePort(PedidoGatewayPort pedidoGatewayPort, ProdutoGatewayPort produtoGatewayPort, ClienteGatewayPort clienteGatewayPort) {
+        return new FazerCheckoutPedidoUseCase(pedidoGatewayPort, produtoGatewayPort, clienteGatewayPort);
     }
 
     @Bean

--- a/src/main/java/br/com/fiap/soat/techChallenge/controllers/PedidoController.java
+++ b/src/main/java/br/com/fiap/soat/techChallenge/controllers/PedidoController.java
@@ -1,7 +1,7 @@
 package br.com.fiap.soat.techChallenge.controllers;
 
 import br.com.fiap.soat.techChallenge.entities.Pedido;
-import br.com.fiap.soat.techChallenge.interfaces.usecases.FazerPedidoUseCasePort;
+import br.com.fiap.soat.techChallenge.interfaces.usecases.FazerCheckoutPedidoUseCasePort;
 import br.com.fiap.soat.techChallenge.interfaces.usecases.ObterPedidosUseCasePort;
 import br.com.fiap.soat.techChallenge.responses.PedidoResponse;
 import br.com.fiap.soat.techChallenge.usecases.model.ComandoDeNovoPedido;
@@ -11,16 +11,16 @@ import java.util.stream.Collectors;
 
 public class PedidoController {
 
-    private final FazerPedidoUseCasePort fazerPedidoUseCase;
+    private final FazerCheckoutPedidoUseCasePort fazerCheckoutPedidoUseCase;
     private final ObterPedidosUseCasePort obterPedidosUseCase;
 
-    public PedidoController(FazerPedidoUseCasePort fazerPedidoUseCase, ObterPedidosUseCasePort obterPedidosUseCase) {
-        this.fazerPedidoUseCase = fazerPedidoUseCase;
+    public PedidoController(FazerCheckoutPedidoUseCasePort fazerCheckoutPedidoUseCase, ObterPedidosUseCasePort obterPedidosUseCase) {
+        this.fazerCheckoutPedidoUseCase = fazerCheckoutPedidoUseCase;
         this.obterPedidosUseCase = obterPedidosUseCase;
     }
 
-    public PedidoResponse fazerPedido(ComandoDeNovoPedido comandoDeNovoPedido) {
-        Pedido pedido = fazerPedidoUseCase.execute(comandoDeNovoPedido);
+    public PedidoResponse fazerCheckoutPedido(ComandoDeNovoPedido comandoDeNovoPedido) {
+        Pedido pedido = fazerCheckoutPedidoUseCase.execute(comandoDeNovoPedido);
         return PedidoResponse.fromDomain(pedido);
     }
 

--- a/src/main/java/br/com/fiap/soat/techChallenge/entities/StatusDoPagamento.java
+++ b/src/main/java/br/com/fiap/soat/techChallenge/entities/StatusDoPagamento.java
@@ -1,0 +1,7 @@
+package br.com.fiap.soat.techChallenge.entities;
+
+public enum StatusDoPagamento {
+    PENDENTE,
+    APROVADO,
+    RECUSADO
+}

--- a/src/main/java/br/com/fiap/soat/techChallenge/entities/StatusDoPedido.java
+++ b/src/main/java/br/com/fiap/soat/techChallenge/entities/StatusDoPedido.java
@@ -1,8 +1,8 @@
 package br.com.fiap.soat.techChallenge.entities;
 
 public enum StatusDoPedido {
-    PAGAMENTO_PENDENTE,
-    PREPARO_PENDENTE,
-    RETIRADA_PENDENTE,
+    RECEBIDO,
+    EM_PREPARACAO,
+    PRONTO,
     FINALIZADO
 }

--- a/src/main/java/br/com/fiap/soat/techChallenge/interfaces/usecases/FazerCheckoutPedidoUseCasePort.java
+++ b/src/main/java/br/com/fiap/soat/techChallenge/interfaces/usecases/FazerCheckoutPedidoUseCasePort.java
@@ -3,6 +3,6 @@ package br.com.fiap.soat.techChallenge.interfaces.usecases;
 import br.com.fiap.soat.techChallenge.usecases.model.ComandoDeNovoPedido;
 import br.com.fiap.soat.techChallenge.entities.Pedido;
 
-public interface FazerPedidoUseCasePort {
+public interface FazerCheckoutPedidoUseCasePort {
     Pedido execute(ComandoDeNovoPedido comandoDeNovoPedido);
 }

--- a/src/main/java/br/com/fiap/soat/techChallenge/usecases/FazerCheckoutPedidoUseCase.java
+++ b/src/main/java/br/com/fiap/soat/techChallenge/usecases/FazerCheckoutPedidoUseCase.java
@@ -7,17 +7,17 @@ import br.com.fiap.soat.techChallenge.interfaces.gateways.ProdutoGatewayPort;
 import br.com.fiap.soat.techChallenge.usecases.model.ComandoDeNovoPedido;
 import br.com.fiap.soat.techChallenge.usecases.model.ItemDoComandoDeNovoPedido;
 import br.com.fiap.soat.techChallenge.interfaces.gateways.PedidoGatewayPort;
-import br.com.fiap.soat.techChallenge.interfaces.usecases.FazerPedidoUseCasePort;
+import br.com.fiap.soat.techChallenge.interfaces.usecases.FazerCheckoutPedidoUseCasePort;
 import br.com.fiap.soat.techChallenge.entities.*;
 
 import java.math.BigDecimal;
 
-public class FazerPedidoUseCase implements FazerPedidoUseCasePort {
+public class FazerCheckoutPedidoUseCase implements FazerCheckoutPedidoUseCasePort {
     private final PedidoGatewayPort pedidoGatewayPort;
     private final ProdutoGatewayPort produtoGatewayPort;
     private final ClienteGatewayPort clienteGatewayPort;
 
-    public FazerPedidoUseCase(
+    public FazerCheckoutPedidoUseCase(
             PedidoGatewayPort pedidoGatewayPort,
             ProdutoGatewayPort produtoGatewayPort,
             ClienteGatewayPort clienteGatewayPort
@@ -31,7 +31,7 @@ public class FazerPedidoUseCase implements FazerPedidoUseCasePort {
     public Pedido execute(ComandoDeNovoPedido comandoDeNovoPedido) {
         Pedido pedido = new Pedido();
 
-        pedido.setStatus(StatusDoPedido.PAGAMENTO_PENDENTE);
+        pedido.setStatus(StatusDoPedido.RECEBIDO);
 
         if (comandoDeNovoPedido.getClienteId() != null) {
             Cliente cliente = clienteGatewayPort


### PR DESCRIPTION
- Alterando nomenclatura para deixar mais claro que é o endpoint de checkout
- Alterando enum de status de pedido, e criando enum para status de pagamento